### PR TITLE
Fix default reconnectionDelayMax

### DIFF
--- a/src/SocketIO.elm
+++ b/src/SocketIO.elm
@@ -47,7 +47,7 @@ Socket.io itself.
 -}
 defaultOptions : Options
 defaultOptions =
-    Options False True 1000 500 20000
+    Options False True 1000 5000 20000
 
 {-| Create a socket, given a hostname and options.
 


### PR DESCRIPTION
Updated reconnectionDelayMax to socket.io-client's default: https://github.com/socketio/socket.io-client/blob/41956806a7d4da382c043d15efb2abe7c21a24d9/lib/manager.js#L51

Looks like the dropped 0 was a simple typo, but it had the effect of forcing the client to hit the server twice a second with no ability to back away. Now it will back away to a max of once per 5 seconds upon reconnection failure.